### PR TITLE
Feature: Allow changing animated view

### DIFF
--- a/Sources/AnimatableView.swift
+++ b/Sources/AnimatableView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public class AnimatedView: UIView, AnimatableView {
-    public override init(frame: CGRect) {
+    public required override init(frame: CGRect) {
         super.init(frame: frame)
         self.backgroundColor = UIColor.clear
     }

--- a/Sources/CheckpointSegmentedArcProgressView.swift
+++ b/Sources/CheckpointSegmentedArcProgressView.swift
@@ -19,6 +19,8 @@ public class CheckpointSegmentedArcProgressView: SegmentedArcProgressView {
         }
     }
     
+    public var ViewType: AnimatedView.Type = StarView.self
+    
     private var slotSize = CGSize(width: 20.0, height: 20.0)
     
     private var slots: [AnimatedView] = []
@@ -84,7 +86,7 @@ public class CheckpointSegmentedArcProgressView: SegmentedArcProgressView {
         self.slots.removeAll()
         // instantiate and attach the checkpoint views to the parent view.
         for _ in 1...self.checkpointLocations.count {
-            let view = StarView(frame: CGRect.zero)
+            let view = ViewType.init(frame: .zero)
             self.addSubview(view)
             self.slots.append(view)
         }

--- a/Sources/CheckpointSegmentedArcProgressView.swift
+++ b/Sources/CheckpointSegmentedArcProgressView.swift
@@ -19,7 +19,7 @@ public class CheckpointSegmentedArcProgressView: SegmentedArcProgressView {
         }
     }
     
-    public var ViewType: AnimatedView.Type = StarView.self
+    public var CheckpointViewType: AnimatedView.Type = StarView.self
     
     private var slotSize = CGSize(width: 20.0, height: 20.0)
     
@@ -86,7 +86,7 @@ public class CheckpointSegmentedArcProgressView: SegmentedArcProgressView {
         self.slots.removeAll()
         // instantiate and attach the checkpoint views to the parent view.
         for _ in 1...self.checkpointLocations.count {
-            let view = ViewType.init(frame: .zero)
+            let view = CheckpointViewType.init(frame: .zero)
             self.addSubview(view)
             self.slots.append(view)
         }

--- a/Sources/StarView.swift
+++ b/Sources/StarView.swift
@@ -65,7 +65,7 @@ public class StarView: AnimatedView {
         }
     }
     
-    public override init(frame: CGRect) {
+    public required init(frame: CGRect) {
         super.init(frame: frame)
     }
     


### PR DESCRIPTION
**Description:** 

Allow the developer to change the view associated to the checkpoint view

```swift
@IBOutlet weak var arcView: CheckpointSegmentedArcProgressView! {
    didSet {
        arcView.CheckpointViewType = StarView.self
    }
}
```

Firstly, `Generics` was used to do that but it is not `Storyboard` Compatible 😞